### PR TITLE
Update AvaxAssetId

### DIFF
--- a/Example-Avalanche-Environment.postman_environment.json
+++ b/Example-Avalanche-Environment.postman_environment.json
@@ -44,7 +44,7 @@
 		},
 		{
 			"key": "avaxAssetId",
-			"value": "2TrXx5kLGWa9RP3RiYWi7VkmNbppwPU4DCmTdqwuKzGFE7fsvP",
+			"value": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
 			"enabled": true
 		},
 		{


### PR DESCRIPTION
The variable `avaxAssetId` seems not to be set to the right ID. 
I update it from `2TrXx5kLGWa9RP3RiYWi7VkmNbppwPU4DCmTdqwuKzGFE7fsvP` to `2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe`.