### PR TITLE
v1.1.0-RC

### DIFF
--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2722,7 +2722,7 @@
 							"response": []
 						},
 						{
-							"name": "getContainerByIndex Copy",
+							"name": "getContainerByID",
 							"request": {
 								"method": "POST",
 								"header": [],


### PR DESCRIPTION
## Add RPC ➕ 

Add `index.getContainerByID` for

* X-Chain Transactions
* X-Chain Vertices
* P-Chain Blocks
* C-Chain Blocks

## Default Encoding 👨‍💻  

Set default `encoding` param value to `hex` to each of the following RPC calls.

* `index.getLastAccepted`
* `index.getContainerByIndex`
* `index.getContainerByID`
* `index.getContainerRange`
* `index.getIndex`
* `index.isAccepted`
* `avm.buildGenesis`
  * Added `encoding: "cb58"` due to the following error `"message": "problem formatting asset definition memo due to: invalid input checksum",` when using this memo: `0x666f6f626172`
* `avm.getUTXOs`
* `avm.mintNFT`
  * Added `encoding: "cb58"` due to the following error `"message": "problem decoding payload bytes: invalid input checksum",` when using this memo: `0x666f6f626172`
* `avm.getTx`
* `avm.issueTx`
  * Added `encoding: "cb58"` due to the following error `"message": "problem decoding transaction: invalid input checksum",` when using this memo: `0x666f6f626172`
* `avax.getAtomicTx`
* `avax.getUTXOs`
* `avax.issueTx`
* `keystore.exportUser`
* `keystore.importUser`
* `platform.getRewardUTXOs`
* `platform.getStake`
* `platform.getTx`
* `platform.getUTXOs`
* `platform.issueTx`