### PR TITLE
v1.6.1-rc

### DIFF
--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -415,267 +415,6 @@
 					"response": []
 				},
 				{
-					"name": "createAddress",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.createAddress\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new address controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createaddress)"
-					},
-					"response": []
-				},
-				{
-					"name": "createAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "createFixedCapAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"denomination\": 0,  \n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createfixedcapasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "createNFTAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            },\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintTx` and `signMintTx`. The asset can be sent with `avm.sendNFT`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createnftasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "createVariableCapAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "export",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000         ,\n        \"assetID\": \"AVAX\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Export a non-AVAX asset from the X-Chain to the C-Chain. After calling this method, you must call the C-Chain’s `import` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexport)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportkey)"
-					},
-					"response": []
-				},
-				{
-					"name": "getAddressTxs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAddressTxs\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\",\n        \"assetID\": \"AVAX\",\n        \"pageSize\": 20,\n        \"cursor\": 0\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Returns all transactions that change the balance of the given address. A transaction is said to change an address's balance if either is true:\n\n*   A UTXO that the transaction consumes was at least partially owned by the address.\n*   A UTXO that the transaction produces is at least partially owned by the address.\n    \n\nNote: Indexing (`index-transactions`) must be enabled in the X-chain config. [More info](https://docs.avax.network/build/avalanchego-apis/x-chain#avm-get-address-txs-api)"
-					},
-					"response": []
-				},
-				{
-					"name": "getAllBalances",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get the balances of all assets controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getallbalances)"
-					},
-					"response": []
-				},
-				{
 					"name": "getAssetDescription",
 					"request": {
 						"method": "POST",
@@ -705,44 +444,13 @@
 					"response": []
 				},
 				{
-					"name": "getBalance",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var template = `",
-									"    <table bgcolor=\"#FFFFFF\">",
-									"        <tr>",
-									"            <th>Name</th>",
-									"            <th>Email</th>",
-									"        </tr>",
-									"",
-									"        {{#each response}}",
-									"            <tr>",
-									"                <td>{{name}}</td>",
-									"                <td>{{email}}</td>",
-									"            </tr>",
-									"        {{/each}}",
-									"    </table>",
-									"`;",
-									"",
-									"// Set visualizer",
-									"pm.visualizer.set(template, {",
-									"    // Pass the response body parsed as JSON as `data`",
-									"    response: pm.response.json()",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
+					"name": "getBlock",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"avm.getBalance\",\n  \"params\" :{\n      \"address\":\"{{xchainAddress}}\",\n      \"assetID\": \"{{avaxAssetId}}\"\n  }\n} ",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getBlock\",\n    \"params\" :{\n        \"blockID\": \"\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -760,7 +468,65 @@
 								"X"
 							]
 						},
-						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettx)"
+					},
+					"response": []
+				},
+				{
+					"name": "getBlockByHeight",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getBlockByHeight\",\n    \"params\" :{\n        \"height\": 0,\n        \"encoding\": \"hex\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettx)"
+					},
+					"response": []
+				},
+				{
+					"name": "getHeight",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getHeight\",\n    \"params\" :{}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettx)"
 					},
 					"response": []
 				},
@@ -852,64 +618,6 @@
 					"response": []
 				},
 				{
-					"name": "import",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.import\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
-					},
-					"response": []
-				},
-				{
 					"name": "issueTx",
 					"request": {
 						"method": "POST",
@@ -935,180 +643,6 @@
 							]
 						},
 						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
-					},
-					"response": []
-				},
-				{
-					"name": "listAddresses",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.listAddresses\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "List addresses controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-listaddresses)"
-					},
-					"response": []
-				},
-				{
-					"name": "mint",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mint)"
-					},
-					"response": []
-				},
-				{
-					"name": "mintNFT",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" ,\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Mint more of a non-fungible asset (an asset created with `avm.createNFTAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mintnft)"
-					},
-					"response": []
-				},
-				{
-					"name": "send",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
-					},
-					"response": []
-				},
-				{
-					"name": "sendMultiple",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendMultiple\",\n    \"params\" :{ \n        \"outputs\": [\n            {\n                \"assetID\" : \"{{avaxAssetId}}\",\n                \"to\"      : \"{{xchainAddress}}\",\n                \"amount\"  : 1000000000\n            }\n        ],\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendmultiple)"
-					},
-					"response": []
-				},
-				{
-					"name": "sendNFT",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendnft)"
 					},
 					"response": []
 				}
@@ -3176,214 +2710,6 @@
 			"description": "This API can be used to access basic information about the node."
 		},
 		{
-			"name": "IPC",
-			"item": [
-				{
-					"name": "publishBlockchain",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.publishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/ipcs",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"ipcs"
-							]
-						},
-						"description": "Register a blockchain so it publishes accepted vertices to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-publishblockchain)"
-					},
-					"response": []
-				},
-				{
-					"name": "unpublishBlockchain",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.unpublishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/ipcs",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"ipcs"
-							]
-						},
-						"description": "Deregister a blockchain so that it no longer publishes to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-unpublishblockchain)"
-					},
-					"response": []
-				}
-			],
-			"description": "The IPC API allows users to create a UNIX domain socket for a blockchain to publish to. When the blockchain accepts a vertex/block it will publish the vertex to the socket.\n\nA node will only expose this API if it is started with command-line argument `api-ipcs-enabled=true`. [More info](https://docs.avax.network/v1.0/en/api/ipc/)"
-		},
-		{
-			"name": "Keystore",
-			"item": [
-				{
-					"name": "createUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.createUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Create a new user with the specified username and password. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-createuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "deleteUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.deleteUser\",\n    \"params\" : {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Delete a user. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-deleteuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"keystore.exportUser\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Export a user. The user can be imported to another node with `keystore.importUser`. The user’s password remains encrypted. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-exportuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "importUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.importUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"user\"    :\"0x0000b79e54bb3452985874844fd02ce47671725850111b14d5b06d4b3e142ec852b39d1be2bdead684977bc0a1bfa6eeb06e000000040000004066687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f292500000000000000000000000000000000000000000000000000000000000000000000004c00000000002a92a15386259d71410fe602a9a1e2207a7afae3efd8d86f142577405476e5337a0736ba095b0fe911cb3100000018226dc5aec589008bc87ce142d5488d942f7e9d37374be99f0000003466687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f29253cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030b46ad90c1ef2f22282a9ab9c045cf190506148a7afcf4e94360e7e4109ef9abbc4aa97dd84533a5b081c0da489e205f00000001825e30947b222849b4f69b0a1eaf1dd49c82f5b64995d3c4e00000040faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de00000000000000000000000000000000000000000000000000000000000000000000004c00000000002a098545758bbf938acd508762ffff24bd2e8e0f80313fb0957c51fea30df6f304a94568c30dfb06257deb00000018e722d87e7d5964aa8a8772b0985d0723d398681ef29fad7900000034faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030722156f457680f16cf010d7cb3b350aaf210ae9ed58aaf89017f0046c5380ddf76fb944a6ff9a287a6a6e6c6303c751a000000183edfb66b8b01e6197507cde7e4909f816d3accf753155f96b346b48c\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-importuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "listUsers",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.listUsers\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "List the users in this keystore. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-listusers)"
-					},
-					"response": []
-				}
-			],
-			"description": "Every node has a built-in keystore. Clients create users on the keystore, which act as identities to be used when interacting with blockchains. A keystore exists at the node level, so if you create a user on a node it exists only on that node. However, users may be imported and exported using this API. \n\n**You should only create a keystore user on a node that you operate, as the node operator has access to your plaintext password.**\n\n[More info](https://docs.avax.network/v1.0/en/api/keystore)"
-		},
-		{
 			"name": "Metrics",
 			"item": [
 				{
@@ -3416,267 +2742,6 @@
 			"name": "PlatformVM",
 			"item": [
 				{
-					"name": "addDelegator",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetdelegator)"
-					},
-					"response": []
-				},
-				{
-					"name": "addSubnetValidator",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformaddnondefaultsubnetvalidator)"
-					},
-					"response": []
-				},
-				{
-					"name": "addValidator",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a validator to the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetvalidator)"
-					},
-					"response": []
-				},
-				{
-					"name": "createAddress",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createAddress\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetdelegator)"
-					},
-					"response": []
-				},
-				{
-					"name": "createBlockchain",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"encoding\": \"hex\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Create a new blockchain. Currently only supports creation of new instances of the AVM and the Timestamp VM. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformcreateblockchain)"
-					},
-					"response": []
-				},
-				{
-					"name": "createSubnet",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Create an unsigned transaction to create a new Subnet.\n\nThe unsigned transaction must be signed with the key of the account paying the transaction fee.\n\nThe Subnet’s ID is the ID of the transaction that creates it (ie the response from `issueTx` when issuing the signed transaction. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformcreatesubnet)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\":54321,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `platform.importKey`. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportkey)"
-					},
-					"response": []
-				},
-				{
-					"name": "getBalance",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"addresses\":[\"{{pchainAddress}}\"]    \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetbalance)"
-					},
-					"response": []
-				},
-				{
 					"name": "getBlock",
 					"request": {
 						"method": "POST",
@@ -3702,35 +2767,6 @@
 							]
 						},
 						"description": "Get a block by its ID. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetblock)"
-					},
-					"response": []
-				},
-				{
-					"name": "getBlockchains",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchains)"
 					},
 					"response": []
 				},
@@ -3851,35 +2887,6 @@
 					"response": []
 				},
 				{
-					"name": "getMaxStakeAmount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
-					},
-					"response": []
-				},
-				{
 					"name": "getMinStake",
 					"request": {
 						"method": "POST",
@@ -3938,64 +2945,6 @@
 					"response": []
 				},
 				{
-					"name": "getRewardUTXOs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the UTXOs that were rewarded after the provided transaction's staking or delegation period ended."
-					},
-					"response": []
-				},
-				{
-					"name": "getStake",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"],\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the staked amount for an array of addresses [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstake)"
-					},
-					"response": []
-				},
-				{
 					"name": "getStakingAssetID",
 					"request": {
 						"method": "POST",
@@ -4021,35 +2970,6 @@
 							]
 						},
 						"description": "Retrieve an assetID for a subnet’s staking asset. Currently this always returns the Primary Network’s staking assetID. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstakingassetid)"
-					},
-					"response": []
-				},
-				{
-					"name": "getSubnets",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getSubnets\",\n    \"params\": {\n        \"ids\": [\"{{avalancheSubnetId}}\"]\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get all the Subnets that exist. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetsubnets)"
 					},
 					"response": []
 				},
@@ -4228,64 +3148,6 @@
 					"response": []
 				},
 				{
-					"name": "importAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Complete a transfer of AVAX from the X-Chain to the C-Chain.\n\nBefore this method is called, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More Info](https://docs.avax.network/v1.0/en/api/platform/#avmimportava)"
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.importKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformimportkey)"
-					},
-					"response": []
-				},
-				{
 					"name": "issueTx",
 					"request": {
 						"method": "POST",
@@ -4311,35 +3173,6 @@
 							]
 						},
 						"description": "Issue a transaction to the Platform Chain. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformissuetx)"
-					},
-					"response": []
-				},
-				{
-					"name": "listAddresses",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.listAddresses\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the addresses controlled by the given user. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformlistaddresses)"
 					},
 					"response": []
 				},


### PR DESCRIPTION
## Added avm block APIs

- avm.getBlock
- avm.getBlockByHeight
- avm.getHeight

## Deprecated all ipcs APIs

- ipcs.publishBlockchain
- ipcs.unpublishBlockchain
- ipcs.getPublishedBlockchains

## Deprecated all keystore APIs

- keystore.createUser
- keystore.deleteUser
- keystore.listUsers
- keystore.importUser
- keystore.exportUser

## Deprecated various avm APIs

- avm.getAddressTxs
- avm.getBalance
- avm.getAllBalances
- avm.createAsset
- avm.createFixedCapAsset
- avm.createVariableCapAsset
- avm.createNFTAsset
- avm.createAddress
- avm.listAddresses
- avm.exportKey
- avm.importKey
- avm.mint
- avm.sendNFT
- avm.mintNFT
- avm.import
- avm.export
- avm.send
- avm.sendMultiple

## Deprecated various platformvm APIs

- platform.exportKey
- platform.importKey
- platform.getBalance
- platform.createAddress
- platform.listAddresses
- platform.getSubnets
- platform.addValidator
- platform.addDelegator
- platform.addSubnetValidator
- platform.createSubnet
- platform.exportAVAX
- platform.importAVAX
- platform.createBlockchain
- platform.getBlockchains
- platform.getStake
- platform.getMaxStakeAmount
- platform.getRewardUTXOs