### PR TITLE
v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Postman collection for [Avalanche](https://docs.avax.network).
 ## Contributing
 
 We're hoping to continuously keep this collection up-to-date with the [Avalanche APIs](https://docs.avax.network/v1.0/en/api/intro-apis/), and also add [data visualizations](https://learning.postman.com/docs/sending-requests/visualizer/#visualizing-response-data). If you're able to help improve the Avalanche Postman Collection in any way, first create a feature branch by branching off of `master`, next make the improvements on your feature branch and lastly create a [pull request](https://github.com/cgcardona/avalanche-postman-collection/pulls) to merge your work back in to `master`.
+
+
+## Version
+
+v1.6.1


### PR DESCRIPTION
Diff can be [seen here](https://github.com/ava-labs/avalanche-postman-collection/pull/25)

This PR adds:

- avm.getBlock
- avm.getBlockByHeight
- avm.getHeight


**Deprecated all ipcs APIs**

- ipcs.publishBlockchain
- ipcs.unpublishBlockchain
- ipcs.getPublishedBlockchains
- Deprecated all keystore APIs
- keystore.createUser
- keystore.deleteUser
- keystore.listUsers
- keystore.importUser
- keystore.exportUser

**Deprecated Avm APIs**

- avm.getAddressTxs
- avm.getBalance
- avm.getAllBalances
- avm.createAsset
- avm.createFixedCapAsset
- avm.createVariableCapAsset
- avm.createNFTAsset
- avm.createAddress
- avm.listAddresses
- avm.exportKey
- avm.importKey
- avm.mint
- avm.sendNFT
- avm.mintNFT
- avm.import
- avm.export
- avm.send
- avm.sendMultiple

**Deprecated platformvm APIs**

- platform.exportKey
- platform.importKey
- platform.getBalance
- platform.createAddress
- platform.listAddresses
- platform.getSubnets
- platform.addValidator
- platform.addDelegator
- platform.addSubnetValidator
- platform.createSubnet
- platform.exportAVAX
- platform.importAVAX
- platform.createBlockchain
- platform.getBlockchains
- platform.getStake
- platform.getMaxStakeAmount
- platform.getRewardUTXOs

## Env Vars

- `xchainBlockID`
- `xhcainBlockHeight`