### PR TITLE
Update links / Add APIs / Deprecate `avm.getTxStatus`

### DIFF
--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1182,6 +1182,96 @@
 						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmsendnft)"
 					},
 					"response": []
+				},
+				{
+					"name": "wallet_issueTx",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "//Endpoint deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"wallet.issueTx\",\n    \"params\" :{\n        \"tx\":\"0x00000009de31b4d8b22991d51aa6aa1fc733f23a851a8c9400000000000186a0000000005f041280000000005f9ca900000030390000000000000001fceda8f90fcb5d30614b99d79fc4baa29307762668f16eb0259a57c2d3b78c875c86ec2045792d4df2d926c40f829196e0bb97ee697af71f5b0a966dabff749634c8b729855e937715b0e44303fd1014daedc752006011b730\",\n        \"encoding\": \"hex\"\n        }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X/wallet",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X",
+								"wallet"
+							]
+						},
+						"description": "Send a signed transaction to the network and assume the TX will be accepted. `encoding` specifies the format of the signed transaction. Can only be `hex` when a value is provided. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#walletissuetx)"
+					},
+					"response": []
+				},
+				{
+					"name": "wallet_send",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"wallet.send\",\n    \"params\" :{\n        \"assetID\"   : \"AVAX\",\n        \"amount\"    : 10000,\n        \"to\"        : \"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5\",\n        \"memo\"      : \"hi, mom!\",\n        \"from\"      : [\"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5\"],\n        \"changeAddr\": \"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8\",\n        \"username\"  : \"userThatControlsAtLeast10000OfThisAsset\",\n        \"password\"  : \"myPassword\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X/wallet",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X",
+								"wallet"
+							]
+						},
+						"description": "Send a quantity of an asset to an address and assume the TX will be accepted so that future calls can use the modified UTXO set. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#walletsend)"
+					},
+					"response": []
+				},
+				{
+					"name": "wallet_sendMultiple",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"wallet.sendMultiple\",\n    \"params\" :{\n        \"outputs\": [\n            {\n                \"assetID\" : \"AVAX\",\n                \"to\"      : \"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5\",\n                \"amount\"  : 1000000000\n            },\n            {\n                \"assetID\" : \"26aqSTpZuWDAVtRmo44fjCx4zW6PDEx3zy9Qtp2ts1MuMFn9FB\",\n                \"to\"      : \"X-avax18knvhxx8uhc0mwlgrfyzjcm2wrd6e60w37xrjq\",\n                \"amount\"  : 10\n            }\n        ],\n        \"memo\"      : \"hi, mom!\",\n        \"from\"      : [\"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5\"],\n        \"changeAddr\": \"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8\",\n        \"username\"  : \"username\",\n        \"password\"  : \"myPassword\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X/wallet",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X",
+								"wallet"
+							]
+						},
+						"description": "Send multiple transfers of `amount` of `assetID`, to a specified address from a list of owned of addresses and assume the TX will be accepted so that future calls can use the modified UTXO set. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#walletsendmultiple)"
+					},
+					"response": []
 				}
 			],
 			"description": "The X-Chain, Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances of the AVM. [More info](https://docs.avax.network/v1.0/en/api/avm)"
@@ -1366,6 +1456,36 @@
 							]
 						},
 						"description": "Getting an account’s balance."
+					},
+					"response": []
+				},
+				{
+					"name": "eth_getChainConfig",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"eth_getChainConfig\",\n    \"params\" :[]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "`eth_getChainConfig` returns chain config. This API is enabled by default with `internal-eth` namespace. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#eth_getchainconfig)"
 					},
 					"response": []
 				},
@@ -2148,6 +2268,161 @@
 						"description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes."
 					},
 					"response": []
+				},
+				{
+					"name": "admin_setLogLevel",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.setLogLevel\",\n    \"params\": {\n        \"level\":\"info\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}//ext/bc/C/admin",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"",
+								"ext",
+								"bc",
+								"C",
+								"admin"
+							]
+						},
+						"description": "Sets the log level of the C-Chain. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#adminsetloglevel)"
+					},
+					"response": []
+				},
+				{
+					"name": "admin_startCPUProfiler",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.startCPUProfiler\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}//ext/bc/C/admin",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"",
+								"ext",
+								"bc",
+								"C",
+								"admin"
+							]
+						},
+						"description": "Starts a CPU profile. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#adminstartcpuprofiler)"
+					},
+					"response": []
+				},
+				{
+					"name": "admin_stopCPUProfiler",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.stopCPUProfiler\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}//ext/bc/C/admin",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"",
+								"ext",
+								"bc",
+								"C",
+								"admin"
+							]
+						},
+						"description": "Stops and writes a CPU profile. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#adminstopcpuprofiler)"
+					},
+					"response": []
+				},
+				{
+					"name": "admin_memoryProfile",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.memoryProfile\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}//ext/bc/C/admin",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"",
+								"ext",
+								"bc",
+								"C",
+								"admin"
+							]
+						},
+						"description": "Runs and writes a memory profile. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#adminmemoryprofile)"
+					},
+					"response": []
+				},
+				{
+					"name": "admin_lockProfile",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.lockProfile\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}//ext/bc/C/admin",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"",
+								"ext",
+								"bc",
+								"C",
+								"admin"
+							]
+						},
+						"description": "Runs a mutex profile writing to the `coreth_performance_c` directory. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#adminlockprofile)"
+					},
+					"response": []
 				}
 			],
 			"description": "This document describes the API of the C-Chain, which is an instance of the Ethereum Virtual Machine (EVM.)\n\nNote: Ethereum has its own notion of `networkID` and `chainID`. The C-Chain uses `1` and `43110` for these values, obtained using the `net_version` and `eth_chainId` methods shown below. These have no relationship to AVA’s view of networkID and chainID, and are purely internal to the C-Chain. [More info](https://docs.avax.network/v1.0/en/api/evm)"
@@ -2179,7 +2454,7 @@
 								"health"
 							]
 						},
-						"description": "Get health check on this node. [More info](https://docs.avax.network/apis/avalanchego/apis/health#get-request)"
+						"description": "Get health check on this node. [More info](https://docs.avax.network/apis/avalanchego/apis/health#methods)"
 					},
 					"response": []
 				}

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -410,7 +410,7 @@
 								"avm"
 							]
 						},
-						"description": "Given a JSON representation of this Virtual Machine’s genesis state, create the byte representation of that state. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmbuildgenesis)"
+						"description": "Given a JSON representation of this Virtual Machine’s genesis state, create the byte representation of that state. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmbuildgenesis)"
 					},
 					"response": []
 				},
@@ -439,36 +439,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new address controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createaddress)"
-					},
-					"response": []
-				},
-				{
-					"name": "createAsset - DEPRECATED",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
+						"description": "Create a new address controlled by the given user. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmcreateaddress)"
 					},
 					"response": []
 				},
@@ -497,7 +468,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createfixedcapasset)"
+						"description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmcreatefixedcapasset)"
 					},
 					"response": []
 				},
@@ -526,7 +497,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintTx` and `signMintTx`. The asset can be sent with `avm.sendNFT`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createnftasset)"
+						"description": "Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintTx` and `signMintTx`. The asset can be sent with `avm.sendNFT`. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmcreatenftasset)"
 					},
 					"response": []
 				},
@@ -555,7 +526,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
+						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmcreatevariablecapasset)"
 					},
 					"response": []
 				},
@@ -584,7 +555,7 @@
 								"X"
 							]
 						},
-						"description": "Export a non-AVAX asset from the X-Chain to the C-Chain. After calling this method, you must call the C-Chain’s `import` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexport)"
+						"description": "Export a non-AVAX asset from the X-Chain to the C-Chain. After calling this method, you must call the C-Chain’s `import` method to complete the transfer. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmexport)"
 					},
 					"response": []
 				},
@@ -613,7 +584,7 @@
 								"X"
 							]
 						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportkey)"
+						"description": "Get the private key that controls a given address.  \nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmexportkey)"
 					},
 					"response": []
 				},
@@ -642,7 +613,7 @@
 								"X"
 							]
 						},
-						"description": "Returns all transactions that change the balance of the given address. A transaction is said to change an address's balance if either is true:\n\n*   A UTXO that the transaction consumes was at least partially owned by the address.\n*   A UTXO that the transaction produces is at least partially owned by the address.\n    \n\nNote: Indexing (`index-transactions`) must be enabled in the X-chain config. [More info](https://docs.avax.network/build/avalanchego-apis/x-chain#avm-get-address-txs-api)"
+						"description": "Returns all transactions that change the balance of the given address. A transaction is said to change an address's balance if either is true:\n\n- A UTXO that the transaction consumes was at least partially owned by the address.\n- A UTXO that the transaction produces is at least partially owned by the address.\n    \n\nNote: Indexing (`index-transactions`) must be enabled in the X-chain config. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetaddresstxs)"
 					},
 					"response": []
 				},
@@ -671,7 +642,7 @@
 								"X"
 							]
 						},
-						"description": "Get the balances of all assets controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getallbalances)"
+						"description": "Get the balances of all assets controlled by a given address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetallbalances)"
 					},
 					"response": []
 				},
@@ -700,7 +671,7 @@
 								"X"
 							]
 						},
-						"description": "Get information about an asset. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getassetdescription)"
+						"description": "Get information about an asset. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetassetdescription)"
 					},
 					"response": []
 				},
@@ -740,7 +711,7 @@
 								"X"
 							]
 						},
-						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetbalance)"
 					},
 					"response": []
 				},
@@ -780,7 +751,7 @@
 								"X"
 							]
 						},
-						"description": "Returns the block with the given id. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+						"description": "Returns the block with the given id. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetblock)"
 					},
 					"response": []
 				},
@@ -820,7 +791,7 @@
 								"X"
 							]
 						},
-						"description": "Returns block at the given height. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+						"description": "Returns block at the given height. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetblockbyheight)"
 					},
 					"response": []
 				},
@@ -860,7 +831,7 @@
 								"X"
 							]
 						},
-						"description": "Returns the height of the last accepted block. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+						"description": "Returns the height of the last accepted block. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetheight)"
 					},
 					"response": []
 				},
@@ -889,18 +860,18 @@
 								"X"
 							]
 						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettx)"
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgettx)"
 					},
 					"response": []
 				},
 				{
-					"name": "getTxStatus",
+					"name": "getTxStatus - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avm.getTxStatus\",\n    \"params\": {\n        \"txID\": \"{{txID}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.10.0.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avm.getTxStatus\",\n    \"params\": {\n        \"txID\": \"{{txID}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -918,7 +889,7 @@
 								"X"
 							]
 						},
-						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettxstatus)"
+						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgettxstatus)"
 					},
 					"response": []
 				},
@@ -947,7 +918,7 @@
 								"X"
 							]
 						},
-						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getutxos)"
+						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmgetutxos)"
 					},
 					"response": []
 				},
@@ -976,7 +947,7 @@
 								"X"
 							]
 						},
-						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
+						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmimport)"
 					},
 					"response": []
 				},
@@ -1005,7 +976,7 @@
 								"X"
 							]
 						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
+						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmimportkey)"
 					},
 					"response": []
 				},
@@ -1034,7 +1005,7 @@
 								"X"
 							]
 						},
-						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
+						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmissuetx)"
 					},
 					"response": []
 				},
@@ -1063,7 +1034,7 @@
 								"X"
 							]
 						},
-						"description": "List addresses controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-listaddresses)"
+						"description": "List addresses controlled by the given user. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmlistaddresses)"
 					},
 					"response": []
 				},
@@ -1092,7 +1063,7 @@
 								"X"
 							]
 						},
-						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mint)"
+						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmmint)"
 					},
 					"response": []
 				},
@@ -1121,7 +1092,7 @@
 								"X"
 							]
 						},
-						"description": "Mint more of a non-fungible asset (an asset created with `avm.createNFTAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mintnft)"
+						"description": "Mint more of a non-fungible asset (an asset created with `avm.createNFTAsset`.) [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmmintnft)"
 					},
 					"response": []
 				},
@@ -1150,7 +1121,7 @@
 								"X"
 							]
 						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmsend)"
 					},
 					"response": []
 				},
@@ -1179,7 +1150,7 @@
 								"X"
 							]
 						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendmultiple)"
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmsendmultiple)"
 					},
 					"response": []
 				},
@@ -1208,7 +1179,7 @@
 								"X"
 							]
 						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendnft)"
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/apis/avalanchego/apis/x-chain#avmsendnft)"
 					},
 					"response": []
 				}
@@ -1244,7 +1215,7 @@
 								"rpc"
 							]
 						},
-						"description": "Get the base fee for the next block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_baseFee)"
+						"description": "Get the base fee for the next block. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#eth_basefee)"
 					},
 					"response": []
 				},
@@ -1274,7 +1245,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting the most recent block number. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-the-most-recent-block-number)"
+						"description": "Getting the most recent block number."
 					},
 					"response": []
 				},
@@ -1304,7 +1275,7 @@
 								"rpc"
 							]
 						},
-						"description": "Call a contract. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#call-a-contract)"
+						"description": "Call a contract."
 					},
 					"response": []
 				},
@@ -1334,7 +1305,7 @@
 								"rpc"
 							]
 						},
-						"description": "Not well documented in JSON-RPC references. See instead EIP694. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-the-chain-id)"
+						"description": "Not well documented in JSON-RPC references. See instead EIP694."
 					},
 					"response": []
 				},
@@ -1364,7 +1335,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting an account’s non-AVAX balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-non-avax-balance)"
+						"description": "Getting an account’s non-AVAX balance. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#eth_getassetbalance)"
 					},
 					"response": []
 				},
@@ -1394,7 +1365,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting an account’s balance. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-an-accounts-balance)"
+						"description": "Getting an account’s balance."
 					},
 					"response": []
 				},
@@ -1424,7 +1395,7 @@
 								"rpc"
 							]
 						},
-						"description": "Get the priority fee needed to be included in a block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_maxPriorityFeePerGas)"
+						"description": "Get the priority fee needed to be included in a block. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#eth_maxpriorityfeepergas)"
 					},
 					"response": []
 				},
@@ -1454,7 +1425,7 @@
 								"rpc"
 							]
 						},
-						"description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#signing-a-transaction)"
+						"description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction."
 					},
 					"response": []
 				},
@@ -1484,7 +1455,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting an account’s nonce. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-an-accounts-nonce)"
+						"description": "Getting an account’s nonce."
 					},
 					"response": []
 				},
@@ -1514,7 +1485,7 @@
 								"rpc"
 							]
 						},
-						"description": "Send a raw transaction.\n\nExample below shows a raw transaction published to the network and its associated transaction hash. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#send-a-raw-transaction)"
+						"description": "Send a raw transaction.\n\nExample below shows a raw transaction published to the network and its associated transaction hash."
 					},
 					"response": []
 				},
@@ -1544,7 +1515,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting a block by hash. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-a-block-by-hash)"
+						"description": "Getting a block by hash."
 					},
 					"response": []
 				},
@@ -1574,7 +1545,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting a block by number. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-block-by-number)"
+						"description": "Getting a block by number."
 					},
 					"response": []
 				},
@@ -1604,7 +1575,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting a transaction by hash. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-by-hash)"
+						"description": "Getting a transaction by hash."
 					},
 					"response": []
 				},
@@ -1634,7 +1605,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting a transaction receipt. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-receipt)"
+						"description": "Getting a transaction receipt."
 					},
 					"response": []
 				},
@@ -1664,7 +1635,7 @@
 								"avax"
 							]
 						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Send AVAX from the X-Chain to an account on the P-Chain.  \nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaxexport)"
 					},
 					"response": []
 				},
@@ -1694,7 +1665,7 @@
 								"avax"
 							]
 						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Send AVAX from the X-Chain to an account on the P-Chain.  \nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaxexportavax)"
 					},
 					"response": []
 				},
@@ -1724,7 +1695,7 @@
 								"avax"
 							]
 						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportkey)\n\n"
+						"description": "Get the private key that controls a given address.  \nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaxexportkey)"
 					},
 					"response": []
 				},
@@ -1754,7 +1725,7 @@
 								"avax"
 							]
 						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaxgetatomictx)"
 					},
 					"response": []
 				},
@@ -1784,7 +1755,7 @@
 								"avax"
 							]
 						},
-						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgettxstatus)"
+						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaxgetatomictxstatus)"
 					},
 					"response": []
 				},
@@ -1814,7 +1785,7 @@
 								"avax"
 							]
 						},
-						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaxgetutxos)"
 					},
 					"response": []
 				},
@@ -1844,7 +1815,7 @@
 								"avax"
 							]
 						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Send AVAX from the X-Chain to an account on the P-Chain.  \nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaximport)"
 					},
 					"response": []
 				},
@@ -1874,7 +1845,7 @@
 								"avax"
 							]
 						},
-						"description": "Import AVAX from the X-Chain to an account on the C-Chain.\nBefore calling this method, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/evm/#evmimportavax)"
+						"description": "Import AVAX from the X-Chain to an account on the C-Chain.  \nBefore calling this method, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaximportavax)"
 					},
 					"response": []
 				},
@@ -1904,7 +1875,7 @@
 								"avax"
 							]
 						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportkey)"
+						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaximportkey)"
 					},
 					"response": []
 				},
@@ -1934,7 +1905,7 @@
 								"avax"
 							]
 						},
-						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
+						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/apis/avalanchego/apis/c-chain#avaxissuetx)"
 					},
 					"response": []
 				},
@@ -1964,7 +1935,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting the network ID. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-network-id)"
+						"description": "Getting the network ID."
 					},
 					"response": []
 				},
@@ -2054,7 +2025,7 @@
 								"rpc"
 							]
 						},
-						"description": "Listing accounts loaded in EVM node. [More info](https://docs.avax.network/v1.0/en/api/evm/#listing-accounts-loaded-in-evm-node)"
+						"description": "Listing accounts loaded in EVM node."
 					},
 					"response": []
 				},
@@ -2084,7 +2055,7 @@
 								"rpc"
 							]
 						},
-						"description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization. [More info](https://docs.avax.network/v1.0/en/api/evm/#unlocking-an-account)"
+						"description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization."
 					},
 					"response": []
 				},
@@ -2114,7 +2085,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting count of pending transactions.\n\n“Pending” transactions will be non-zero during periods of heavy network use. “Queued” transactions indicate transactions have been submitted with nonce values ahead of the next expected value for an address, which places them on hold until a transaction with the next expected nonce value is submitted. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-count-of-pending-transactions)"
+						"description": "Getting count of pending transactions.\n\n“Pending” transactions will be non-zero during periods of heavy network use. “Queued” transactions indicate transactions have been submitted with nonce values ahead of the next expected value for an address, which places them on hold until a transaction with the next expected nonce value is submitted."
 					},
 					"response": []
 				},
@@ -2144,7 +2115,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting the current client version. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-current-client-version)"
+						"description": "Getting the current client version."
 					},
 					"response": []
 				},
@@ -2174,7 +2145,7 @@
 								"rpc"
 							]
 						},
-						"description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.avax.network/v1.0/en/api/evm/#calculate-a-cryptographic-hash)"
+						"description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes."
 					},
 					"response": []
 				}
@@ -2208,7 +2179,7 @@
 								"health"
 							]
 						},
-						"description": "Get health check on this node. [More info](https://docs.avax.network/build/apis/health-api#health-getliveness)"
+						"description": "Get health check on this node. [More info](https://docs.avax.network/apis/avalanchego/apis/health#get-request)"
 					},
 					"response": []
 				}
@@ -2247,7 +2218,7 @@
 										"tx"
 									]
 								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2277,7 +2248,7 @@
 										"tx"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyindex)"
 							},
 							"response": []
 						},
@@ -2307,7 +2278,7 @@
 										"tx"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
+								"description": "Returns containers with indices in \\[startIndex, startIndex+1, ... , startIndex + numToFetch - 1\\]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerrange)"
 							},
 							"response": []
 						},
@@ -2337,7 +2308,7 @@
 										"tx"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetindex)"
 							},
 							"response": []
 						},
@@ -2367,7 +2338,7 @@
 										"tx"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetlastaccepted)"
 							},
 							"response": []
 						},
@@ -2397,7 +2368,7 @@
 										"tx"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexisaccepted)"
 							},
 							"response": []
 						}
@@ -2432,7 +2403,7 @@
 										"vtx"
 									]
 								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2462,7 +2433,7 @@
 										"vtx"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyindex)"
 							},
 							"response": []
 						},
@@ -2492,7 +2463,7 @@
 										"vtx"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
+								"description": "Returns containers with indices in \\[startIndex, startIndex+1, ... , startIndex + numToFetch - 1\\]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerrange)"
 							},
 							"response": []
 						},
@@ -2522,7 +2493,7 @@
 										"vtx"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetindex)"
 							},
 							"response": []
 						},
@@ -2552,7 +2523,7 @@
 										"vtx"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetlastaccepted)"
 							},
 							"response": []
 						},
@@ -2582,7 +2553,7 @@
 										"vtx"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexisaccepted)"
 							},
 							"response": []
 						}
@@ -2617,7 +2588,7 @@
 										"block"
 									]
 								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2647,7 +2618,7 @@
 										"block"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyindex)"
 							},
 							"response": []
 						},
@@ -2677,7 +2648,7 @@
 										"block"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
+								"description": "Returns containers with indices in \\[startIndex, startIndex+1, ... , startIndex + numToFetch - 1\\]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerrange)"
 							},
 							"response": []
 						},
@@ -2707,7 +2678,7 @@
 										"block"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetindex)"
 							},
 							"response": []
 						},
@@ -2737,7 +2708,7 @@
 										"block"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetlastaccepted)"
 							},
 							"response": []
 						},
@@ -2767,7 +2738,7 @@
 										"block"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexisaccepted)"
 							},
 							"response": []
 						}
@@ -2802,7 +2773,7 @@
 										"block"
 									]
 								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2832,7 +2803,7 @@
 										"block"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerbyindex)"
 							},
 							"response": []
 						},
@@ -2862,7 +2833,7 @@
 										"block"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
+								"description": "Returns containers with indices in \\[startIndex, startIndex+1, ... , startIndex + numToFetch - 1\\]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetcontainerrange)"
 							},
 							"response": []
 						},
@@ -2892,7 +2863,7 @@
 										"block"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetindex)"
 							},
 							"response": []
 						},
@@ -2922,7 +2893,7 @@
 										"block"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexgetlastaccepted)"
 							},
 							"response": []
 						},
@@ -2952,7 +2923,7 @@
 										"block"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/apis/avalanchego/apis/index-api#indexisaccepted)"
 							},
 							"response": []
 						}
@@ -2988,7 +2959,7 @@
 								"info"
 							]
 						},
-						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#infoisbootstrapped)"
+						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infoisbootstrapped)"
 					},
 					"response": []
 				},
@@ -3016,7 +2987,7 @@
 								"info"
 							]
 						},
-						"description": "Given a blockchain’s alias, get its ID. [More info](https://docs.avax.network/build/avalanchego-apis/info#infogetblockchainid)"
+						"description": "Given a blockchain’s alias, get its ID. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogetblockchainid)"
 					},
 					"response": []
 				},
@@ -3044,7 +3015,7 @@
 								"info"
 							]
 						},
-						"description": "Get the ID of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnetworkid)"
+						"description": "Get the ID of the network this node is participating in. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogetnetworkid)"
 					},
 					"response": []
 				},
@@ -3072,7 +3043,7 @@
 								"info"
 							]
 						},
-						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnetworkname)"
+						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogetnetworkname)"
 					},
 					"response": []
 				},
@@ -3100,7 +3071,7 @@
 								"info"
 							]
 						},
-						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeid)"
+						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogetnodeid)"
 					},
 					"response": []
 				},
@@ -3128,7 +3099,7 @@
 								"info"
 							]
 						},
-						"description": "Get the IP of this node. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeip)"
+						"description": "Get the IP of this node. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogetnodeip)"
 					},
 					"response": []
 				},
@@ -3156,7 +3127,7 @@
 								"info"
 							]
 						},
-						"description": "Get the version of this node. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeversion)"
+						"description": "Get the version of this node. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogetnodeversion)"
 					},
 					"response": []
 				},
@@ -3184,7 +3155,7 @@
 								"info"
 							]
 						},
-						"description": "Get the transaction fee of the network. [More info](https://docs.avax.network/v1.0/en/api/info/#infogettxfee)"
+						"description": "Get the transaction fee of the network. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogettxfee)"
 					},
 					"response": []
 				},
@@ -3212,7 +3183,7 @@
 								"info"
 							]
 						},
-						"description": "Get the virtual machines installed on this node. [More info](https://docs.avax.network/build/avalanchego-apis/info#infogetvms)"
+						"description": "Get the virtual machines installed on this node. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infogetvms)"
 					},
 					"response": []
 				},
@@ -3240,7 +3211,7 @@
 								"info"
 							]
 						},
-						"description": "Get description of peer connections. [More info](https://docs.avax.network/build/apis/info-api#info-peers)"
+						"description": "Get description of peer connections. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infopeers)"
 					},
 					"response": []
 				},
@@ -3268,7 +3239,7 @@
 								"info"
 							]
 						},
-						"description": "Returns the network's observed uptime of this node. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#info-uptime)"
+						"description": "Returns the network's observed uptime of this node. [More info](https://docs.avax.network/apis/avalanchego/apis/info#infouptime)"
 					},
 					"response": []
 				}
@@ -3302,7 +3273,7 @@
 								"ipcs"
 							]
 						},
-						"description": "Register a blockchain so it publishes accepted vertices to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-publishblockchain)"
+						"description": "Register a blockchain so it publishes accepted vertices to a Unix domain socket. [More info](https://docs.avax.network/apis/avalanchego/apis/ipc#ipcspublishblockchain)"
 					},
 					"response": []
 				},
@@ -3330,7 +3301,7 @@
 								"ipcs"
 							]
 						},
-						"description": "Deregister a blockchain so that it no longer publishes to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-unpublishblockchain)"
+						"description": "Deregister a blockchain so that it no longer publishes to a Unix domain socket. [More info](https://docs.avax.network/apis/avalanchego/apis/ipc#ipcsunpublishblockchain)"
 					},
 					"response": []
 				}
@@ -3364,7 +3335,7 @@
 								"keystore"
 							]
 						},
-						"description": "Create a new user with the specified username and password. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-createuser)"
+						"description": "Create a new user with the specified username and password. [More info](https://docs.avax.network/apis/avalanchego/apis/keystore#keystorecreateuser)"
 					},
 					"response": []
 				},
@@ -3392,7 +3363,7 @@
 								"keystore"
 							]
 						},
-						"description": "Delete a user. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-deleteuser)"
+						"description": "Delete a user. [More info](https://docs.avax.network/apis/avalanchego/apis/keystore#keystoredeleteuser)"
 					},
 					"response": []
 				},
@@ -3420,7 +3391,7 @@
 								"keystore"
 							]
 						},
-						"description": "Export a user. The user can be imported to another node with `keystore.importUser`. The user’s password remains encrypted. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-exportuser)"
+						"description": "Export a user. The user can be imported to another node with `keystore.importUser`. The user’s password remains encrypted. [More info](https://docs.avax.network/apis/avalanchego/apis/keystore#keystoreexportuser)"
 					},
 					"response": []
 				},
@@ -3448,7 +3419,7 @@
 								"keystore"
 							]
 						},
-						"description": "Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-importuser)"
+						"description": "Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported. [More info](https://docs.avax.network/apis/avalanchego/apis/keystore#keystoreimportuser)"
 					},
 					"response": []
 				},
@@ -3476,7 +3447,7 @@
 								"keystore"
 							]
 						},
-						"description": "List the users in this keystore. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-listusers)"
+						"description": "List the users in this keystore. [More info](https://docs.avax.network/apis/avalanchego/apis/keystore#keystorelistusers)"
 					},
 					"response": []
 				}
@@ -3505,7 +3476,7 @@
 								"metrics"
 							]
 						},
-						"description": "To get the node metrics. [More info](https://docs.avax.network/build/apis/metrics-api)"
+						"description": "To get the node metrics. [More info](https://docs.avax.network/apis/avalanchego/apis/metrics)"
 					},
 					"response": []
 				}
@@ -3540,7 +3511,7 @@
 								"P"
 							]
 						},
-						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetdelegator)"
+						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformadddelegator)"
 					},
 					"response": []
 				},
@@ -3569,7 +3540,7 @@
 								"P"
 							]
 						},
-						"description": "Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformaddnondefaultsubnetvalidator)"
+						"description": "Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformaddsubnetvalidator)"
 					},
 					"response": []
 				},
@@ -3598,7 +3569,7 @@
 								"P"
 							]
 						},
-						"description": "Add a validator to the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetvalidator)"
+						"description": "Add a validator to the Default Subnet. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformaddvalidator)"
 					},
 					"response": []
 				},
@@ -3627,7 +3598,7 @@
 								"P"
 							]
 						},
-						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetdelegator)"
+						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformcreateaddress)"
 					},
 					"response": []
 				},
@@ -3656,7 +3627,7 @@
 								"P"
 							]
 						},
-						"description": "Create a new blockchain. Currently only supports creation of new instances of the AVM and the Timestamp VM. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformcreateblockchain)"
+						"description": "Create a new blockchain. Currently only supports creation of new instances of the AVM and the Timestamp VM. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformcreateblockchain)"
 					},
 					"response": []
 				},
@@ -3685,7 +3656,7 @@
 								"P"
 							]
 						},
-						"description": "Create an unsigned transaction to create a new Subnet.\n\nThe unsigned transaction must be signed with the key of the account paying the transaction fee.\n\nThe Subnet’s ID is the ID of the transaction that creates it (ie the response from `issueTx` when issuing the signed transaction. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformcreatesubnet)"
+						"description": "Create an unsigned transaction to create a new Subnet.\n\nThe unsigned transaction must be signed with the key of the account paying the transaction fee.\n\nThe Subnet’s ID is the ID of the transaction that creates it (ie the response from `issueTx` when issuing the signed transaction. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformcreatesubnet)"
 					},
 					"response": []
 				},
@@ -3714,7 +3685,7 @@
 								"P"
 							]
 						},
-						"description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportavax)"
+						"description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.  \nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.  \nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformexportavax)"
 					},
 					"response": []
 				},
@@ -3743,7 +3714,7 @@
 								"P"
 							]
 						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `platform.importKey`. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportkey)"
+						"description": "Get the private key that controls a given address.  \nThe returned private key can be added to a user with `platform.importKey`. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformexportkey)"
 					},
 					"response": []
 				},
@@ -3772,7 +3743,7 @@
 								"P"
 							]
 						},
-						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetbalance)"
+						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetbalance)"
 					},
 					"response": []
 				},
@@ -3830,7 +3801,7 @@
 								"P"
 							]
 						},
-						"description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchains)"
+						"description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetblockchains)"
 					},
 					"response": []
 				},
@@ -3859,7 +3830,7 @@
 								"P"
 							]
 						},
-						"description": "Get the status of a blockchain. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchainstatus)"
+						"description": "Get the status of a blockchain. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetblockchainstatus)"
 					},
 					"response": []
 				},
@@ -3888,7 +3859,7 @@
 								"P"
 							]
 						},
-						"description": "Returns an upper bound on the number of AVAX that exist. This is an upper bound because it does not account for burnt tokens, including transaction fees. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentsupply)"
+						"description": "Returns an upper bound on the number of AVAX that exist. This is an upper bound because it does not account for burnt tokens, including transaction fees. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetcurrentsupply)"
 					},
 					"response": []
 				},
@@ -3917,7 +3888,7 @@
 								"P"
 							]
 						},
-						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
+						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetcurrentvalidators)"
 					},
 					"response": []
 				},
@@ -3946,7 +3917,7 @@
 								"P"
 							]
 						},
-						"description": "Returns the height of the last accepted block [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetheight)"
+						"description": "Returns the height of the last accepted block [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetheight)"
 					},
 					"response": []
 				},
@@ -3975,7 +3946,7 @@
 								"P"
 							]
 						},
-						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
+						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetmaxstakeamount)"
 					},
 					"response": []
 				},
@@ -4004,7 +3975,7 @@
 								"P"
 							]
 						},
-						"description": "Returns the minimum stake amount [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetminstake)"
+						"description": "Returns the minimum stake amount [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetminstake)"
 					},
 					"response": []
 				},
@@ -4033,7 +4004,7 @@
 								"P"
 							]
 						},
-						"description": "List the validators in the pending validator set of the specified Subnet. Each validator is not currently validating the Subnet but will in the future. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetpendingvalidators)"
+						"description": "List the validators in the pending validator set of the specified Subnet. Each validator is not currently validating the Subnet but will in the future. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetpendingvalidators)"
 					},
 					"response": []
 				},
@@ -4062,7 +4033,7 @@
 								"P"
 							]
 						},
-						"description": "Returns the UTXOs that were rewarded after the provided transaction's staking or delegation period ended."
+						"description": "Returns the UTXOs that were rewarded after the provided transaction's staking or delegation period ended. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetrewardutxos)"
 					},
 					"response": []
 				},
@@ -4091,7 +4062,7 @@
 								"P"
 							]
 						},
-						"description": "Returns the staked amount for an array of addresses [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstake)"
+						"description": "Returns the staked amount for an array of addresses [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetstake)"
 					},
 					"response": []
 				},
@@ -4120,7 +4091,7 @@
 								"P"
 							]
 						},
-						"description": "Retrieve an assetID for a subnet’s staking asset. Currently this always returns the Primary Network’s staking assetID. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstakingassetid)"
+						"description": "Retrieve an assetID for a subnet’s staking asset. Currently this always returns the Primary Network’s staking assetID. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetstakingassetid)"
 					},
 					"response": []
 				},
@@ -4149,7 +4120,7 @@
 								"P"
 							]
 						},
-						"description": "Get all the Subnets that exist. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetsubnets)"
+						"description": "Get all the Subnets that exist. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetsubnets)"
 					},
 					"response": []
 				},
@@ -4178,7 +4149,7 @@
 								"P"
 							]
 						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgettimestamp)"
 					},
 					"response": []
 				},
@@ -4207,7 +4178,7 @@
 								"P"
 							]
 						},
-						"description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/build/avalanchego-apis/p-chain#platformgettotalstake)"
+						"description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgettotalstake)"
 					},
 					"response": []
 				},
@@ -4236,7 +4207,7 @@
 								"P"
 							]
 						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgettx)"
 					},
 					"response": []
 				},
@@ -4265,7 +4236,7 @@
 								"P"
 							]
 						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgettxstatus)"
 					},
 					"response": []
 				},
@@ -4294,7 +4265,7 @@
 								"P"
 							]
 						},
-						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetutxos)"
 					},
 					"response": []
 				},
@@ -4323,7 +4294,7 @@
 								"P"
 							]
 						},
-						"description": "Get the validators and their weights of a subnet or the Primary Network at a given P-Chain height. [More info](https://docs.avax.network/build/avalanchego-apis/platform-chain-p-chain-api#platform-getvalidatorsat)"
+						"description": "Get the validators and their weights of a subnet or the Primary Network at a given P-Chain height. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetvalidatorsat)"
 					},
 					"response": []
 				},
@@ -4352,7 +4323,7 @@
 								"P"
 							]
 						},
-						"description": "Complete a transfer of AVAX from the X-Chain to the C-Chain.\n\nBefore this method is called, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More Info](https://docs.avax.network/v1.0/en/api/platform/#avmimportava)"
+						"description": "Complete a transfer of AVAX from the X-Chain to the C-Chain.\n\nBefore this method is called, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More Info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformimportavax)"
 					},
 					"response": []
 				},
@@ -4381,7 +4352,7 @@
 								"P"
 							]
 						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformimportkey)"
+						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformimportkey)"
 					},
 					"response": []
 				},
@@ -4410,7 +4381,7 @@
 								"P"
 							]
 						},
-						"description": "Issue a transaction to the Platform Chain. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformissuetx)"
+						"description": "Issue a transaction to the Platform Chain. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformissuetx)"
 					},
 					"response": []
 				},
@@ -4439,7 +4410,7 @@
 								"P"
 							]
 						},
-						"description": "List the addresses controlled by the given user. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformlistaddresses)"
+						"description": "List the addresses controlled by the given user. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformlistaddresses)"
 					},
 					"response": []
 				},
@@ -4468,7 +4439,7 @@
 								"P"
 							]
 						},
-						"description": "Sample validators from the specified Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformsamplevalidators)"
+						"description": "Sample validators from the specified Subnet. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformsamplevalidators)"
 					},
 					"response": []
 				},
@@ -4497,7 +4468,7 @@
 								"P"
 							]
 						},
-						"description": "Get the Subnet that validates a given blockchain. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformvalidatedby)"
+						"description": "Get the Subnet that validates a given blockchain. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformvalidatedby)"
 					},
 					"response": []
 				},
@@ -4526,7 +4497,7 @@
 								"P"
 							]
 						},
-						"description": "Get the IDs of the blockchains a Subnet validates. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformvalidates)"
+						"description": "Get the IDs of the blockchains a Subnet validates. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformvalidates)"
 					},
 					"response": []
 				}


### PR DESCRIPTION
1.  Replaced all links from Description with actual ones. The old ones were outdated.

2. Deprecated `avm.getTxStatus`

3. Added the following:

**EVM**

- `eth.getChainConfig`
- `admin.setLogLevel`
- `admin.startCPUProfiler`
- `admin.stopCPUProfiler`
- `admin.memoryProfile`
- `admin.lockProfile`

**AVM**

- `wallet.issueTx`
- `wallet.send`
- `wallet.sendMultiple`

4. Removed `avm.createAsset` (couldn't find it in docs)